### PR TITLE
Add method for enforcing variable constraints

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -108,12 +108,13 @@ class RiemannianMetric(ffunc.Function):
             value = mp.get(key)
             if value is None:
                 continue
-            self._variable_parameters_set = True
             if isinstance(value, firedrake.Constant):
                 mp[key] = value.dat.data[0]
+                self._variable_parameters_set = True
             elif isinstance(value, ffunc.Function):
                 vp[key] = value
                 mp.pop(key)
+                self._variable_parameters_set = True
             else:
                 vp[key] = firedrake.Constant(value)
 

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -323,7 +323,7 @@ class RiemannianMetric(ffunc.Function):
         P1 = firedrake.FunctionSpace(mesh, "CG", 1)
 
         def interp(f):
-            """
+            r"""
             Try to apply a Clement interpolant.
               * `TypeError` indicates something other than a :class:`Function` passed.
               * `ValueError` indicates the :class:`Function` is not :math:`\mathbb{P}0`.

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -327,7 +327,7 @@ class RiemannianMetric(ffunc.Function):
               * `ValueError` indicates the :class:`Function` is not :math:`\mathbb{P}0`.
             """
             try:
-                return clement_interpolant(f)
+                return clement_interpolant(f, target_space=P1)
             except TypeError:
                 return ffunc.Function(P1).assign(f)
             except ValueError:

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -108,10 +108,7 @@ class RiemannianMetric(ffunc.Function):
             value = mp.get(key)
             if value is None:
                 continue
-            if isinstance(value, firedrake.Constant):
-                mp[key] = value.dat.data[0]
-                self._variable_parameters_set = True
-            elif isinstance(value, ffunc.Function):
+            if isinstance(value, (firedrake.Constant, ffunc.Function)):
                 vp[key] = value
                 mp.pop(key)
                 self._variable_parameters_set = True

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -306,10 +306,17 @@ class RiemannianMetric(ffunc.Function):
         P1 = firedrake.FunctionSpace(mesh, "CG", 1)
 
         def interp(f):
-            if isinstance(f, ffunc.Function):
+            """
+            Try to apply a Clement interpolant.
+              * `TypeError` indicates something other than a :class:`Function` passed.
+              * `ValueError` indicates the :class:`Function` is not :math:`\mathbb{P}0`.
+            """
+            try:
                 return clement_interpolant(f)
-            else:
+            except TypeError:
                 return ffunc.Function(P1).assign(f)
+            except ValueError:
+                return ffunc.Function(P1).interpolate(f)
 
         h_min = interp(self._variable_parameters["dm_plex_metric_h_min"])
         h_max = interp(self._variable_parameters["dm_plex_metric_h_max"])

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -270,14 +270,14 @@ class RiemannianMetric(ffunc.Function):
     # TODO: Implement this on the PETSc side
     #       See https://gitlab.com/petsc/petsc/-/issues/1450
     @PETSc.Log.EventDecorator()
-    def enforce_variable_constraints(self, h_min, h_max, a_max, boundary_tag=None):
+    def enforce_variable_constraints(self, h_min=1.0e-30, h_max=1.0e30, a_max=1.0e5, boundary_tag=None):
         """
         Post-process a metric to enforce minimum and maximum metric magnitudes
         and maximum anisotropy, any of which may vary spatially.
 
-        :arg h_min: minimum tolerated magnitude
-        :arg h_max: maximum tolerated magnitude
-        :arg a_max: maximum tolerated anisotropy
+        :kwarg h_min: minimum tolerated magnitude
+        :kwarg h_max: maximum tolerated magnitude
+        :kwarg a_max: maximum tolerated anisotropy
         :kwarg boundary_tag: optional tag to enforce sizes on.
         """
         mesh = self.function_space().mesh()
@@ -313,7 +313,7 @@ class RiemannianMetric(ffunc.Function):
 
         dim = mesh.topological_dimension()
         if boundary_tag is None:
-            node_set = self.function_space.node_set
+            node_set = self.function_space().node_set
         else:
             bc = firedrake.DirichletBC(self.function_space(), 0, boundary_tag)
             node_set = bc.node_set

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -49,9 +49,9 @@ class RiemannianMetric(ffunc.Function):
             function_space = ffs.TensorFunctionSpace(function_space, "CG", 1)
         self.metric_parameters = {}
         self._variable_parameters = {
-            "dm_plex_metric_h_min": 1.0e-30,
-            "dm_plex_metric_h_max": 1.0e30,
-            "dm_plex_metric_a_max": 1.0e5,
+            "dm_plex_metric_h_min": firedrake.Constant(1.0e-30),
+            "dm_plex_metric_h_max": firedrake.Constant(1.0e30),
+            "dm_plex_metric_a_max": firedrake.Constant(1.0e5),
         }
         super().__init__(function_space, *args, **kwargs)
 

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -101,19 +101,21 @@ class RiemannianMetric(ffunc.Function):
             mp.pop("dm_plex_metric")
 
         # Spatially varying parameters need to be treated differently
-        variable_parameters = {}
+        vp = {}
         for key in ("h_min", "h_max", "a_max"):
             key = f"dm_plex_metric_{key}"
             value = mp.get(key)
             if value is None:
                 continue
-            if isinstance(value, firedrake.Constant):
+            elif isinstance(value, firedrake.Constant):
                 mp[key] = value.dat.data[0]
             elif isinstance(value, ffunc.Function):
-                variable_parameters[key] = value
+                vp[key] = value
                 mp.pop(key)
+            else:
+                vp[key] = firedrake.Constant(value)
 
-        return mp, variable_parameters
+        return mp, vp
 
     def set_parameters(self, metric_parameters={}):
         """

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -270,7 +270,7 @@ class RiemannianMetric(ffunc.Function):
     # TODO: Implement this on the PETSc side
     #       See https://gitlab.com/petsc/petsc/-/issues/1450
     @PETSc.Log.EventDecorator()
-    def enforce_variable_constraints(self, h_min=1.0e-30, h_max=1.0e30, a_max=1.0e5, boundary_tag=None):
+    def _enforce_variable_constraints(self, h_min=1.0e-30, h_max=1.0e30, a_max=1.0e5, boundary_tag=None):
         """
         Post-process a metric to enforce minimum and maximum metric magnitudes
         and maximum anisotropy, any of which may vary spatially.

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -103,6 +103,7 @@ class RiemannianMetric(ffunc.Function):
         # Spatially varying parameters need to be treated differently
         variable_parameters = {}
         for key in ("h_min", "h_max", "a_max"):
+            key = f"dm_plex_metric_{key}"
             value = mp.get(key)
             if value is None:
                 continue

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -674,8 +674,8 @@ class TestEnforceSPD(MetricTestCase):
         expected = RiemannianMetric(P1_ten).interpolate(transpose(metric))
         self.assertAlmostMatching(metric, expected)
 
-    @parameterized.expand([[2], [3]])
-    def test_enforce_h_min(self, dim):
+    @parameterized.expand([(2, False), (2, True), (3, False), (3, True)])
+    def test_enforce_h_min(self, dim, variable):
         """
         Check that the minimum magnitude is correctly applied:
             h_min > h => h := h_min
@@ -684,13 +684,16 @@ class TestEnforceSPD(MetricTestCase):
         h = 0.1
         metric = uniform_metric(mesh, a=1 / h**2)
         h_min = 0.2
-        metric.set_parameters({"dm_plex_metric_h_min": h_min})
-        metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
+        if variable:
+            metric.enforce_variable_constraints(h_min=h_min)
+        else:
+            metric.set_parameters({"dm_plex_metric_h_min": h_min})
+            metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
         expected = uniform_metric(mesh, a=1 / h_min**2)
         self.assertAlmostMatching(metric, expected)
 
-    @parameterized.expand([[2], [3]])
-    def test_enforce_h_max(self, dim):
+    @parameterized.expand([(2, False), (2, True), (3, False), (3, True)])
+    def test_enforce_h_max(self, dim, variable):
         """
         Check that the minimum magnitude is correctly applied:
             h_max < h => h := h_max
@@ -699,13 +702,16 @@ class TestEnforceSPD(MetricTestCase):
         h = 0.1
         metric = uniform_metric(mesh, a=1 / h**2)
         h_max = 0.05
-        metric.set_parameters({"dm_plex_metric_h_max": h_max})
-        metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
+        if variable:
+            metric.enforce_variable_constraints(h_max=h_max)
+        else:
+            metric.set_parameters({"dm_plex_metric_h_max": h_max})
+            metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
         expected = uniform_metric(mesh, a=1 / h_max**2)
         self.assertAlmostMatching(metric, expected)
 
-    @parameterized.expand([[2], [3]])
-    def test_enforce_a_max(self, dim):
+    @parameterized.expand([(2, False), (2, True), (3, False), (3, True)])
+    def test_enforce_a_max(self, dim, variable):
         """
         Check that the maximum anisotropy is correctly applied:
             a_max < a => a := a_max
@@ -716,8 +722,12 @@ class TestEnforceSPD(MetricTestCase):
         M = np.eye(dim)
         M[0][0] = 10.0
         metric.interpolate(as_matrix(M))
-        metric.set_parameters({"dm_plex_metric_a_max": 1.0})
-        metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)
+        a_max = 1.0
+        if variable:
+            metric.enforce_variable_constraints(a_max=a_max)
+        else:
+            metric.set_parameters({"dm_plex_metric_a_max": a_max})
+            metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)
         expected = uniform_metric(mesh, a=10.0)
         self.assertAlmostMatching(metric, expected)
 

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -694,9 +694,8 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_min = 0.2
         if variable:
-            P0 = FunctionSpace(mesh, "DG", 0)
             metric.set_parameters({
-                "dm_plex_metric_h_min": Function(P0).assign(h_min),
+                "dm_plex_metric_h_min": Constant(h_min),
                 "dm_plex_metric_boundary_tag": boundary_tag,
             })
         else:
@@ -731,9 +730,8 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_max = 0.05
         if variable:
-            P0 = FunctionSpace(mesh, "DG", 0)
             metric.set_parameters({
-                "dm_plex_metric_h_max": Function(P0).assign(h_max),
+                "dm_plex_metric_h_max": Constant(h_max),
                 "dm_plex_metric_boundary_tag": boundary_tag,
             })
         else:
@@ -771,9 +769,8 @@ class TestEnforceSPD(MetricTestCase):
         metric.interpolate(as_matrix(M))
         a_max = 1.0
         if variable:
-            P0 = FunctionSpace(mesh, "DG", 0)
             metric.set_parameters({
-                "dm_plex_metric_a_max": Function(P0).assign(a_max),
+                "dm_plex_metric_a_max": Constant(a_max),
                 "dm_plex_metric_boundary_tag": boundary_tag,
             })
         else:

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -85,6 +85,34 @@ class TestSetParameters(MetricTestCase):
         self.assertAlmostEqual(metric._plex.metricGetMinimumMagnitude(), hmin)
         self.assertAlmostEqual(metric.metric_parameters["dm_plex_metric_h_min"], hmin)
 
+    def test_set_a_max(self):
+        amax = 1.0
+        metric = uniform_metric(uniform_mesh(2))
+        metric.set_parameters({"dm_plex_metric_a_max": amax})
+        self.assertAlmostEqual(metric._plex.metricGetMaximumAnisotropy(), amax)
+        self.assertAlmostEqual(metric.metric_parameters["dm_plex_metric_a_max"], amax)
+
+    @parameterized.expand([["h_min"], ["h_max"], ["a_max"]])
+    def test_set_variable(self, key):
+        value = Constant(1.0)
+        metric = uniform_metric(uniform_mesh(2))
+        metric.set_parameters({f"dm_plex_metric_{key}": value})
+        self.assertTrue(f"dm_plex_metric_{key}" not in metric.metric_parameters)
+        self.assertTrue(f"dm_plex_metric_{key}" in metric._variable_parameters)
+        self.assertEqual(metric._variable_parameters[f"dm_plex_metric_{key}"], value)
+
+    def test_set_boundary_tag(self):
+        value = "on_boundary"
+        metric = uniform_metric(uniform_mesh(2))
+        metric.set_parameters()
+        self.assertTrue("dm_plex_metric_boundary_tag" not in metric.metric_parameters)
+        self.assertTrue("dm_plex_metric_boundary_tag" in metric._variable_parameters)
+        self.assertIsNone(metric._variable_parameters["dm_plex_metric_boundary_tag"])
+        metric.set_parameters({"dm_plex_metric_boundary_tag": value})
+        self.assertTrue("dm_plex_metric_boundary_tag" not in metric.metric_parameters)
+        self.assertTrue("dm_plex_metric_boundary_tag" in metric._variable_parameters)
+        self.assertEqual(metric._variable_parameters["dm_plex_metric_boundary_tag"], value)
+
     def test_no_reset(self):
         hmin = 0.1
         hmax = 1.0

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -694,7 +694,7 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_min = 0.2
         if variable:
-            metric.enforce_variable_constraints(h_min=h_min, boundary_tag=boundary_tag)
+            metric._enforce_variable_constraints(h_min=h_min, boundary_tag=boundary_tag)
         else:
             metric.set_parameters({"dm_plex_metric_h_min": h_min})
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
@@ -726,7 +726,7 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_max = 0.05
         if variable:
-            metric.enforce_variable_constraints(h_max=h_max, boundary_tag=boundary_tag)
+            metric._enforce_variable_constraints(h_max=h_max, boundary_tag=boundary_tag)
         else:
             metric.set_parameters({"dm_plex_metric_h_max": h_max})
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
@@ -761,7 +761,7 @@ class TestEnforceSPD(MetricTestCase):
         metric.interpolate(as_matrix(M))
         a_max = 1.0
         if variable:
-            metric.enforce_variable_constraints(a_max=a_max, boundary_tag=boundary_tag)
+            metric._enforce_variable_constraints(a_max=a_max, boundary_tag=boundary_tag)
         else:
             metric.set_parameters({"dm_plex_metric_a_max": a_max})
             metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -694,10 +694,13 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_min = 0.2
         if variable:
-            metric._variable_parameters["dm_plex_metric_h_min"] = h_min
-            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+            P0 = FunctionSpace(mesh, "DG", 0)
+            metric.set_parameters({"dm_plex_metric_h_min": Function(P0).assign(h_min)})
         else:
             metric.set_parameters({"dm_plex_metric_h_min": h_min})
+        if variable:
+            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+        else:
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
         if boundary_tag is None:
             expected = uniform_metric(mesh, a=1 / h_min**2)
@@ -727,10 +730,13 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_max = 0.05
         if variable:
-            metric._variable_parameters["dm_plex_metric_h_max"] = h_max
-            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+            P0 = FunctionSpace(mesh, "DG", 0)
+            metric.set_parameters({"dm_plex_metric_h_max": Function(P0).assign(h_max)})
         else:
             metric.set_parameters({"dm_plex_metric_h_max": h_max})
+        if variable:
+            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+        else:
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
         if boundary_tag is None:
             expected = uniform_metric(mesh, a=1 / h_max**2)
@@ -763,10 +769,13 @@ class TestEnforceSPD(MetricTestCase):
         metric.interpolate(as_matrix(M))
         a_max = 1.0
         if variable:
-            metric._variable_parameters["dm_plex_metric_a_max"] = a_max
-            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+            P0 = FunctionSpace(mesh, "DG", 0)
+            metric.set_parameters({"dm_plex_metric_a_max": Function(P0).assign(a_max)})
         else:
             metric.set_parameters({"dm_plex_metric_a_max": a_max})
+        if variable:
+            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+        else:
             metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)
         if boundary_tag is None:
             expected = uniform_metric(mesh, a=10.0)

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -701,10 +701,8 @@ class TestEnforceSPD(MetricTestCase):
             })
         else:
             metric.set_parameters({"dm_plex_metric_h_min": h_min})
-        if variable:
-            metric._enforce_variable_constraints()
-        else:
-            metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
+        # metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)  # TODO
+        metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=True)
         if boundary_tag is None:
             expected = uniform_metric(mesh, a=1 / h_min**2)
         else:
@@ -740,10 +738,8 @@ class TestEnforceSPD(MetricTestCase):
             })
         else:
             metric.set_parameters({"dm_plex_metric_h_max": h_max})
-        if variable:
-            metric._enforce_variable_constraints()
-        else:
-            metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
+        # metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)  # TODO
+        metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=True)
         if boundary_tag is None:
             expected = uniform_metric(mesh, a=1 / h_max**2)
         else:
@@ -782,10 +778,8 @@ class TestEnforceSPD(MetricTestCase):
             })
         else:
             metric.set_parameters({"dm_plex_metric_a_max": a_max})
-        if variable:
-            metric._enforce_variable_constraints()
-        else:
-            metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)
+        # metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)  # TODO
+        metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=True)
         if boundary_tag is None:
             expected = uniform_metric(mesh, a=10.0)
         else:

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -695,11 +695,14 @@ class TestEnforceSPD(MetricTestCase):
         h_min = 0.2
         if variable:
             P0 = FunctionSpace(mesh, "DG", 0)
-            metric.set_parameters({"dm_plex_metric_h_min": Function(P0).assign(h_min)})
+            metric.set_parameters({
+                "dm_plex_metric_h_min": Function(P0).assign(h_min),
+                "dm_plex_metric_boundary_tag": boundary_tag,
+            })
         else:
             metric.set_parameters({"dm_plex_metric_h_min": h_min})
         if variable:
-            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+            metric._enforce_variable_constraints()
         else:
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
         if boundary_tag is None:
@@ -731,11 +734,14 @@ class TestEnforceSPD(MetricTestCase):
         h_max = 0.05
         if variable:
             P0 = FunctionSpace(mesh, "DG", 0)
-            metric.set_parameters({"dm_plex_metric_h_max": Function(P0).assign(h_max)})
+            metric.set_parameters({
+                "dm_plex_metric_h_max": Function(P0).assign(h_max),
+                "dm_plex_metric_boundary_tag": boundary_tag,
+            })
         else:
             metric.set_parameters({"dm_plex_metric_h_max": h_max})
         if variable:
-            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+            metric._enforce_variable_constraints()
         else:
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
         if boundary_tag is None:
@@ -770,11 +776,14 @@ class TestEnforceSPD(MetricTestCase):
         a_max = 1.0
         if variable:
             P0 = FunctionSpace(mesh, "DG", 0)
-            metric.set_parameters({"dm_plex_metric_a_max": Function(P0).assign(a_max)})
+            metric.set_parameters({
+                "dm_plex_metric_a_max": Function(P0).assign(a_max),
+                "dm_plex_metric_boundary_tag": boundary_tag,
+            })
         else:
             metric.set_parameters({"dm_plex_metric_a_max": a_max})
         if variable:
-            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
+            metric._enforce_variable_constraints()
         else:
             metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)
         if boundary_tag is None:

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -694,7 +694,8 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_min = 0.2
         if variable:
-            metric._enforce_variable_constraints(h_min=h_min, boundary_tag=boundary_tag)
+            metric._variable_parameters["dm_plex_metric_h_min"] = h_min
+            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
         else:
             metric.set_parameters({"dm_plex_metric_h_min": h_min})
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
@@ -726,7 +727,8 @@ class TestEnforceSPD(MetricTestCase):
         metric = uniform_metric(mesh, a=1 / h**2)
         h_max = 0.05
         if variable:
-            metric._enforce_variable_constraints(h_max=h_max, boundary_tag=boundary_tag)
+            metric._variable_parameters["dm_plex_metric_h_max"] = h_max
+            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
         else:
             metric.set_parameters({"dm_plex_metric_h_max": h_max})
             metric.enforce_spd(restrict_sizes=True, restrict_anisotropy=False)
@@ -761,7 +763,8 @@ class TestEnforceSPD(MetricTestCase):
         metric.interpolate(as_matrix(M))
         a_max = 1.0
         if variable:
-            metric._enforce_variable_constraints(a_max=a_max, boundary_tag=boundary_tag)
+            metric._variable_parameters["dm_plex_metric_a_max"] = a_max
+            metric._enforce_variable_constraints(boundary_tag=boundary_tag)
         else:
             metric.set_parameters({"dm_plex_metric_a_max": a_max})
             metric.enforce_spd(restrict_sizes=False, restrict_anisotropy=True)


### PR DESCRIPTION
Closes #35.

The `enforce_spd` method currently only supports constant values for `h_min`, `h_max`, and `a_max`. This method provides a temporary way to enforce variable values, until the functionality is ported over to the PETSc side.