### PR TITLE
51 update install instructions

### DIFF
--- a/install/install_firedrake.sh
+++ b/install/install_firedrake.sh
@@ -34,12 +34,3 @@ curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scri
 python3 firedrake-install --venv-name ${FIREDRAKE_ENV} --package-branch petsc ${PETSC_BRANCH}
 source ${FIREDRAKE_DIR}/bin/activate
 unset PETSC_CONFIGURE_OPTIONS
-
-# Install Animate and test that the adaptation functionality is working
-cd ${FIREDRAKE_DIR}/src
-git clone git@github.com:pyroteus/animate
-cd animate
-make install
-make test
-
-cd ${CWD}

--- a/install/install_firedrake.sh
+++ b/install/install_firedrake.sh
@@ -34,3 +34,5 @@ curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scri
 python3 firedrake-install --venv-name ${FIREDRAKE_ENV} --package-branch petsc ${PETSC_BRANCH}
 source ${FIREDRAKE_DIR}/bin/activate
 unset PETSC_CONFIGURE_OPTIONS
+
+cd ${CWD}

--- a/install/install_firedrake_custom_mpi.sh
+++ b/install/install_firedrake_custom_mpi.sh
@@ -54,3 +54,5 @@ python3 firedrake-install --venv-name ${FIREDRAKE_ENV} --package-branch petsc ${
     --mpicc ${MPICC} --mpicxx ${MPICXX} --mpif90 ${MPIF90} --mpiexec ${MPIEXEC}
 source ${FIREDRAKE_DIR}/bin/activate
 unset PETSC_CONFIGURE_OPTIONS
+
+cd ${CWD}

--- a/install/install_firedrake_custom_mpi.sh
+++ b/install/install_firedrake_custom_mpi.sh
@@ -54,12 +54,3 @@ python3 firedrake-install --venv-name ${FIREDRAKE_ENV} --package-branch petsc ${
     --mpicc ${MPICC} --mpicxx ${MPICXX} --mpif90 ${MPIF90} --mpiexec ${MPIEXEC}
 source ${FIREDRAKE_DIR}/bin/activate
 unset PETSC_CONFIGURE_OPTIONS
-
-# Install Animate and test that the adaptation functionality is working
-cd ${FIREDRAKE_DIR}/src
-git clone git@github.com:pyroteus/animate
-cd animate
-make install
-make test
-
-cd ${CWD}


### PR DESCRIPTION
Removed installation instructions/code from the shell script for animate. 
Shell script should install custom Firedrake only
Separate instructions for cloning animate repository have been detailed in the README.md

Closes #51 