### PR TITLE
Bug-fix for Riemann init from tensor field (copy) with active tape

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -47,8 +47,8 @@ class RiemannianMetric(ffunc.Function):
         """
         if isinstance(function_space, fmesh.MeshGeometry):
             function_space = ffs.TensorFunctionSpace(function_space, "CG", 1)
-        super().__init__(function_space, *args, **kwargs)
         self.metric_parameters = {}
+        super().__init__(function_space, *args, **kwargs)
 
         # Check that we have an appropriate tensor P1 function
         fs = self.function_space()


### PR DESCRIPTION
In the following example
```
from firedrake import *
from animate import RiemannianMetric
from firedrake_adjoint import *
mesh=UnitSquareMesh(1,1)
TP=TensorFunctionSpace(mesh, "CG", 1)
T=Function(TP)
x=RiemannianMetric(T)
```
because the tape is switched on, when RiemannianMetric's `__init__` is called, which in turn calls `__init__ `of Function, the input metric/tensor T is copied onto tape. This uses the RiemannianMetric copy method. It succesfully creates a copy of the tensor and turns it into a RiemannianMetric, but then tries to copy metric_parameters from self (the new Riemannian metric being created) to the copy, but self does not have metric_parameters yet.