### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ outputs/
 plots/
 __pycache__/
 
+.coverage
+
 *.jpg
 *.jpeg
 *.pdf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.10
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ install:
 	@echo "Installing Animate..."
 	@python3 -m pip install -e .
 	@echo "Done."
+	@echo "Setting up pre-commit..."
+	@pre-commit install
+	@echo "Done."
 
 lint:
 	@echo "Checking lint..."

--- a/demos/simple_metric.py
+++ b/demos/simple_metric.py
@@ -7,8 +7,10 @@
 # is usually assumed to be vertex-based, so we need to define the metric in
 # a Continuous Galerkin (CG) P1 tensor function space
 
+
 from firedrake import *
 from animate import *
+
 mesh = UnitSquareMesh(10, 10)
 P1_ten = TensorFunctionSpace(mesh, "CG", 1)
 metric = RiemannianMetric(P1_ten)
@@ -44,11 +46,12 @@ metric.interpolate(as_matrix([[alpha, 0], [0, alpha]]))
 
 new_mesh = adapt(mesh, metric)
 import matplotlib.pyplot as plt
+
 fig, axes = plt.subplots()
 triplot(new_mesh, axes=axes)
-axes.set_aspect('equal')
+axes.set_aspect("equal")
 fig.show()
-fig.savefig('mesh1.jpg')
+fig.savefig("mesh1.jpg")
 
 # .. figure:: mesh1.jpg
 #    :figwidth: 90%
@@ -60,13 +63,13 @@ fig.savefig('mesh1.jpg')
 
 hx = 0.1
 hy = 0.25
-metric.interpolate(as_matrix([[1/hx**2, 0], [0, 1/hy**2]]))
+metric.interpolate(as_matrix([[1 / hx**2, 0], [0, 1 / hy**2]]))
 new_mesh = adapt(mesh, metric)
 fig, axes = plt.subplots()
 triplot(new_mesh, axes=axes)
-axes.set_aspect('equal')
+axes.set_aspect("equal")
 fig.show()
-fig.savefig('mesh2.jpg')
+fig.savefig("mesh2.jpg")
 
 # .. figure:: mesh2.jpg
 #    :figwidth: 90%
@@ -79,19 +82,19 @@ x, y = SpatialCoordinate(mesh)
 r = 0.4
 h1 = 0.02
 h2 = 0.05
-high = as_matrix([[1/h1**2, 0], [0, 1/h1**2]])
-low = as_matrix([[1/h2**2, 0], [0, 1/h2**2]])
-metric.interpolate(conditional(sqrt((x-0.5)**2+(y-0.5)**2) < r, high, low))
+high = as_matrix([[1 / h1**2, 0], [0, 1 / h1**2]])
+low = as_matrix([[1 / h2**2, 0], [0, 1 / h2**2]])
+metric.interpolate(conditional(sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2) < r, high, low))
 new_mesh = adapt(mesh, metric)
 fig, axes = plt.subplots(figsize=(16, 8), ncols=2)
 triplot(mesh, axes=axes[0])
-axes[0].set_aspect('equal')
-axes[0].set_title('Input mesh: 10 x 10')
+axes[0].set_aspect("equal")
+axes[0].set_title("Input mesh: 10 x 10")
 triplot(new_mesh, axes=axes[1])
-axes[1].set_aspect('equal')
-axes[1].set_title('Adapted mesh')
+axes[1].set_aspect("equal")
+axes[1].set_title("Adapted mesh")
 fig.show()
-fig.savefig('mesh3.jpg')
+fig.savefig("mesh3.jpg")
 
 # .. figure:: mesh3.jpg
 #    :figwidth: 90%
@@ -110,19 +113,19 @@ x, y = SpatialCoordinate(mesh)
 r = 0.4
 h1 = 0.02
 h2 = 0.05
-high = as_matrix([[1/h1**2, 0], [0, 1/h1**2]])
-low = as_matrix([[1/h2**2, 0], [0, 1/h2**2]])
-metric.interpolate(conditional(sqrt((x-0.5)**2+(y-0.5)**2) < r, high, low))
+high = as_matrix([[1 / h1**2, 0], [0, 1 / h1**2]])
+low = as_matrix([[1 / h2**2, 0], [0, 1 / h2**2]])
+metric.interpolate(conditional(sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2) < r, high, low))
 new_mesh = adapt(mesh, metric)
 fig, axes = plt.subplots(figsize=(16, 8), ncols=2)
 triplot(mesh, axes=axes[0])
-axes[0].set_aspect('equal')
-axes[0].set_title('Input mesh: 50 x 50')
+axes[0].set_aspect("equal")
+axes[0].set_title("Input mesh: 50 x 50")
 triplot(new_mesh, axes=axes[1])
-axes[1].set_aspect('equal')
-axes[1].set_title('Adapted mesh')
+axes[1].set_aspect("equal")
+axes[1].set_title("Adapted mesh")
 fig.show()
-fig.savefig('mesh4.jpg')
+fig.savefig("mesh4.jpg")
 
 # .. figure:: mesh4.jpg
 #    :figwidth: 90%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+)/
+'''
+
+[tool.pytest.ini_options]
+filterwarnings = [
+	"ignore:`np.bool8` is a deprecated alias for `np.bool_`*:DeprecationWarning",
+	"ignore:unable to find git revision*:UserWarning",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
+black
 flake8
 parameterized
+pre-commit
 pytest
 pytest-xdist
 sympy


### PR DESCRIPTION
Closes #69.

Installed pre-commit hooks are called every time you commit to the repo. In this case, we hook up flake8 and Black so that the code is automatically formatted at each commit. This ensures consistency and removes any need for future reformatting.