### PR TITLE
Naming DMplex of adapted meshes

### DIFF
--- a/animate/adapt.py
+++ b/animate/adapt.py
@@ -79,6 +79,7 @@ class MetricBasedAdaptor(AdaptorBase):
         reordered = to_petsc_local_numbering(v, self.metric.function_space())
         v.destroy()
         newplex = self.metric._plex.adaptMetric(reordered, "Face Sets", "Cell Sets")
+        newplex.setName(self.name + '_topology')
         reordered.destroy()
         return fmesh.Mesh(
             newplex, distribution_parameters={"partition": False}, name=self.name


### PR DESCRIPTION
Closes #14.

One-line addition. I am following firedrake's convention here to name the topology `mesh.name + "_topology"` (as in [firedrake.mesh._generate_default_mesh_topology_name](https://github.com/firedrakeproject/firedrake/blob/48997eb62d34c0ec53735bc3339b85d4dd2f98ed/firedrake/mesh.py#L94))