### PR TITLE
Temporary docker base image revert

### DIFF
--- a/docker/Dockerfile.firedrake
+++ b/docker/Dockerfile.firedrake
@@ -1,4 +1,4 @@
-FROM firedrakeproject/firedrake-vanilla:latest
+FROM firedrakeproject/firedrake-vanilla:2024-02
 
 MAINTAINER Joe Wallwork <joe.wallwork@outlook.com>
 
@@ -24,7 +24,7 @@ RUN bash -c "cd petsc; \
 # Rebuild Firedrake
 RUN bash -c "source firedrake/bin/activate; \
 	cd firedrake/src/firedrake; \
-	firedrake-update --install thetis"
+	firedrake-update"
 
 # Install Animate
 RUN bash -c "source firedrake/bin/activate; \

--- a/install/install_firedrake.sh
+++ b/install/install_firedrake.sh
@@ -8,7 +8,7 @@
 # *** YOU MAY WISH TO EDIT THESE ENVIRONMENT VARIABLES: ***
 
 FIREDRAKE_ENV=firedrake-sep23
-PETSC_BRANCH=jwallwork23/parmmg-rebased
+PETSC_BRANCH=jwallwork23/firedrake-parmmg
 
 # *** YOU SHOULD NOT NEED TO EDIT ANYTHING BELOW. ***
 

--- a/install/install_firedrake_custom_mpi.sh
+++ b/install/install_firedrake_custom_mpi.sh
@@ -8,7 +8,7 @@
 # *** YOU MAY WISH TO EDIT THESE ENVIRONMENT VARIABLES: ***
 
 FIREDRAKE_ENV=firedrake-sep23
-PETSC_BRANCH=jwallwork23/parmmg-rebased
+PETSC_BRANCH=jwallwork23/firedrake-parmmg
 MPICC=/usr/bin/mpicc.mpich
 MPICXX=/usr/bin/mpicxx.mpich
 MPIEXEC=/usr/bin/mpiexec.mpich


### PR DESCRIPTION
Temporary fix for #79: reverting the docker base image to `firedrakeproject/firedrake-vanilla:2024-02` and not installing Thetis. 

Also updated the specified petsc branch in install scripts.