### PR TITLE
Introduce metric parameters documentation

### DIFF
--- a/animate/metric.py
+++ b/animate/metric.py
@@ -194,7 +194,7 @@ class RiemannianMetric(ffunc.Function):
             For more detail, see
             https://www.mmgtools.org/mmg-remesher-try-mmg/mmg-remesher-options/mmg-remesher-option-hausd.
         * `boundary_tag`: Mesh boundary tag to restrict attention to during
-            boundary-specific manipulations. Unset by default, which implies all
+            boundary-specific metric manipulations. Unset by default, which implies all
             boundaries are considered. (Note that this parameter does not currently exist
             in the underlying PETSc implementation.)
         * `no_insert`: Boolean flag for turning off node insertion and deletion during

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -133,6 +133,8 @@ class RiemannianMetric(ffunc.Function):
         Set metric parameter values internally. All options have the prefix
         `dm_plex_metric_` and are listed below (with prefix dropped for brevity):
 
+        * `target_complexity`: Strictly positive target metric complexity value. No
+            default - **must be set**.
         * `h_min`: Minimum tolerated metric magnitude, which allows approximate control
             of minimum element size in the adapted mesh. Supports :class:`~.Constant`
             and :class:`~.Function` input, as well as :class:`float`. Default: 1.0e-30.
@@ -145,8 +147,6 @@ class RiemannianMetric(ffunc.Function):
             Default: 1.0e+05.
         * `p`: :math:`L^p` normalisation order. Supports ``np.inf`` as well as
             :class:`float` values from :math:`[0,\infty)`. Default: 1.0.
-        * `target_complexity`: Strictly positive target metric complexity value. No
-            default - **must be set**.
         * `gradation_factor`: Maximum ratio by which adjacent edges in the adapted mesh
             may differ. Default: 1.3.
         * `hausdorff_number`: Spatial scale factor for the problem. Default: 0.01.

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -186,10 +186,13 @@ class RiemannianMetric(ffunc.Function):
         * `p`: :math:`L^p` normalisation order. Supports ``np.inf`` as well as
             :class:`float` values from :math:`[0,\infty)`. Default: 1.0.
         * `gradation_factor`: Maximum ratio by which adjacent edges in the adapted mesh
-            may differ. Default: 1.3.
+            may differ. Default: 1.3. For more detail, see
+            https://www.mmgtools.org/mmg-remesher-try-mmg/mmg-remesher-options/mmg-remesher-option-hgrad.
         * `hausdorff_number`: Spatial scale factor for the problem. The default value
             0.01 corresponds to an :math:`\mathcal{O}(1)` length scale. A rule of thumb
             is to scale this value appropriately to the length scale of your problem.
+            For more detail, see
+            https://www.mmgtools.org/mmg-remesher-try-mmg/mmg-remesher-options/mmg-remesher-option-hausd.
         * `boundary_tag`: Mesh boundary tag to restrict attention to during
             boundary-specific manipulations. Unset by default, which implies all
             boundaries are considered. (Note that this parameter does not currently exist
@@ -205,7 +208,8 @@ class RiemannianMetric(ffunc.Function):
         * `num_iterations`: Number of adaptation iterations in the parallel case.
             Default: 3.
         * `verbosity`: Verbosity of the mesh adaptation package (-1 = silent,
-            10 = maximum). Default: -1.
+            10 = maximum). Default: -1. For more detail, see
+            https://www.mmgtools.org/mmg-remesher-try-mmg/mmg-remesher-options/mmg-remesher-option-v.
         * `isotropic`: Optimisation for isotropic metrics. (Currently unsupported.)
         * `uniform`: Optimisation for uniform metrics. (Currently unsupported.)
         * `restrict_anisotropy_first`: Specify that anisotropy should be restricted

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -131,7 +131,10 @@ class RiemannianMetric(ffunc.Function):
     def set_parameters(self, metric_parameters={}):
         r"""
         Set metric parameter values internally. All options have the prefix
-        `dm_plex_metric_` and are listed below (with prefix dropped for brevity):
+        `dm_plex_metric_` and are listed below (with prefix dropped for brevity). Note
+        that any parameter which supports :class:`~.Function` values must be in a
+        :math:`\mathbb{P}1` space defined on the same mesh as the metric, i.e., from
+        ``FunctionSpace(mesh, "CG", 1)``.
 
         * `target_complexity`: Strictly positive target metric complexity value. No
             default - **must be set**.

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -133,12 +133,51 @@ class RiemannianMetric(ffunc.Function):
         return mp, vp
 
     def set_parameters(self, metric_parameters={}):
-        """
-        Set metric parameter values internally.
+        r"""
+        Set metric parameter values internally. All options have the prefix
+        `dm_plex_metric_` and are listed below (with prefix dropped for brevity):
 
-        :kwarg metric_parameters: a dictionary of parameters to be passed to PETSc's
-            Riemannian metric implementation. All such options have the prefix
-            `dm_plex_metric_`.
+        * `h_min`: Minimum tolerated metric magnitude, which allows approximate control
+            of minimum element size in the adapted mesh. Supports :class:`~.Constant`
+            and :class:`~.Function` input, as well as :class:`float`. Default: 1.0e-30.
+        * `h_max`: Maximum tolerated metric magnitude, which allows approximate control
+            of maximum element size in the adapted mesh. Supports :class:`~.Constant`
+            and :class:`~.Function` input, as well as :class:`float`. Default: 1.0e+30.
+        * `a_max`: Maximum tolerated metric anisotropy, which allows approximate control
+            of maximum element anisotropy in the adapted mesh. Supports
+            :class:`~.Constant` and :class:`~.Function` input, as well as :class:`float`.
+            Default: 1.0e+05.
+        * `p`: :math:`L^p` normalisation order. Supports ``np.inf`` as well as
+            :class:`float` values from :math:`[0,\infty)`. Default: 1.0.
+        * `target_complexity`: Strictly positive target metric complexity value. No
+            default - **must be set**.
+        * `gradation_factor`: Maximum ratio by which adjacent edges in the adapted mesh
+            may differ. Default: 1.3.
+        * `hausdorff_number`: Spatial scale factor for the problem. Default: 0.01.
+        * `boundary_tag`: Mesh boundary tag to restrict attention to during
+            boundary-specific manipulations. Unset by default, which implies all
+            boundaries are considered. (Note that this parameter does not currently exist
+            in the underlying PETSc implementation.)
+        * `no_insert`: Boolean flag for turning off node insertion and deletion during
+            adaptation. Default: False.
+        * `no_swap`: Boolean flag for turning off edge and face swapping during
+            adaptation. Default: False.
+        * `no_move`: Boolean flag for turning off node movement during adaptation.
+            Default: False.
+        * `no_surf`: Boolean flag for turning off surface modification during adaptation.
+            Default: False.
+        * `num_iterations`: Number of adaptation iterations in the parallel case.
+            Default: 3.
+        * `verbosity`: Verbosity of the mesh adaptation package (-1 = silent,
+            10 = maximum). Default: -1.
+        * `isotropic`: Optimisation for isotropic metrics. (Currently unsupported.)
+        * `uniform`: Optimisation for uniform metrics. (Currently unsupported.)
+        * `restrict_anisotropy_first`: Specify that anisotropy should be restricted
+            before normalisation? (Currently unsupported.)
+
+        :kwarg metric_parameters: parameters as above
+        :type metric_parameters: :class:`dict` with :class:`str` keys and value which
+            may take various types
         """
         mp, vp = self._process_parameters(metric_parameters)
         self._metric_parameters.update(mp)

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -205,8 +205,9 @@ class RiemannianMetric(ffunc.Function):
             Default: False.
         * `no_surf`: Boolean flag for turning off surface modification during adaptation.
             Default: False.
-        * `num_iterations`: Number of adaptation iterations in the parallel case.
-            Default: 3.
+        * `num_iterations`: Number of adaptation-repartitioning iterations in the
+            parallel case. Default: 3. For details on the parallel algorithm, see
+            https://inria.hal.science/hal-02386837.
         * `verbosity`: Verbosity of the mesh adaptation package (-1 = silent,
             10 = maximum). Default: -1. For more detail, see
             https://www.mmgtools.org/mmg-remesher-try-mmg/mmg-remesher-options/mmg-remesher-option-v.

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -187,7 +187,9 @@ class RiemannianMetric(ffunc.Function):
             :class:`float` values from :math:`[0,\infty)`. Default: 1.0.
         * `gradation_factor`: Maximum ratio by which adjacent edges in the adapted mesh
             may differ. Default: 1.3.
-        * `hausdorff_number`: Spatial scale factor for the problem. Default: 0.01.
+        * `hausdorff_number`: Spatial scale factor for the problem. The default value
+            0.01 corresponds to an :math:`\mathcal{O}(1)` length scale. A rule of thumb
+            is to scale this value appropriately to the length scale of your problem.
         * `boundary_tag`: Mesh boundary tag to restrict attention to during
             boundary-specific manipulations. Unset by default, which implies all
             boundaries are considered. (Note that this parameter does not currently exist

--- a/animate/metric.py
+++ b/animate/metric.py
@@ -114,12 +114,8 @@ class RiemannianMetric(ffunc.Function):
             value = mp.get(key)
             if not value:
                 continue
-            if isinstance(value, firedrake.Constant):
-                vp[key] = firedrake.Constant(float(value))
-                mp.pop(key)
-                self._variable_parameters_set = True
-            elif isinstance(value, ffunc.Function):
-                vp[key] = value.copy(deepcopy=True)
+            if isinstance(value, (firedrake.Constant, ffunc.Function)):
+                vp[key] = value
                 mp.pop(key)
                 self._variable_parameters_set = True
             else:

--- a/test/test_adapt.py
+++ b/test/test_adapt.py
@@ -134,7 +134,7 @@ def test_adapt_3d():
     mp = {
         "dm_plex_metric": {
             "target_complexity": 100.0,
-            "normalization_order": 1.0,
+            "p": 1.0,
         }
     }
     metric = uniform_metric(mesh, metric_parameters=mp)

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -306,7 +306,7 @@ class TestNormalisation(MetricTestCase):
             {
                 "dm_plex_metric": {
                     "target_complexity": target,
-                    "normalization_order": 1.0,
+                    "p": 1.0,
                 }
             }
         )
@@ -347,7 +347,7 @@ class TestNormalisation(MetricTestCase):
             {
                 "dm_plex_metric": {
                     "target_complexity": target,
-                    "normalization_order": degree,
+                    "p": degree,
                 }
             }
         )

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -150,12 +150,36 @@ class TestSetParameters(MetricTestCase):
         msg = "Isotropic metric optimisations are not supported in Firedrake."
         self.assertEqual(str(cm.exception), msg)
 
+    def test_restrict_anisotropy_first_notimplemented_error(self):
+        metric = uniform_metric(uniform_mesh(2))
+        with self.assertRaises(NotImplementedError) as cm:
+            metric.set_parameters({"dm_plex_metric_restrict_anisotropy_first": None})
+        msg = "Restricting metric anisotropy first is not supported in Firedrake."
+        self.assertEqual(str(cm.exception), msg)
+
     def test_p_valueerror(self):
         metric = RiemannianMetric(uniform_mesh(2))
         with self.assertRaises(Exception) as cm:
             metric.set_parameters({"dm_plex_metric_p": 0.0})
         msg = "Normalization order must be in [1, inf)"
         self.assertTrue(str(cm.exception).endswith(msg))
+
+    def test_no_prefix_valueerror(self):
+        metric = RiemannianMetric(uniform_mesh(2))
+        with self.assertRaises(ValueError) as cm:
+            metric.set_parameters({"h_max": 1.0e30})
+        msg = (
+            "Unsupported metric parameter 'h_max'."
+            " Metric parameters must start with the prefix 'dm_plex_metric_'."
+        )
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_unsupported_option_valueerror(self):
+        metric = RiemannianMetric(uniform_mesh(2))
+        with self.assertRaises(ValueError) as cm:
+            metric.set_parameters({"dm_plex_metric_a_min": 1.0e-10})
+        msg = "Unsupported metric parameter 'dm_plex_metric_a_min'."
+        self.assertEqual(str(cm.exception), msg)
 
 
 class TestHessianMetric(MetricTestCase):

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -157,23 +157,6 @@ class TestSetParameters(MetricTestCase):
         msg = "Normalization order must be in [1, inf)"
         self.assertTrue(str(cm.exception).endswith(msg))
 
-    def test_deepcopy(self):
-        mesh = uniform_mesh(2)
-        metric1 = RiemannianMetric(TensorFunctionSpace(mesh, "CG", 1))
-        P1 = FunctionSpace(mesh, "CG", 1)
-        mp1 = {
-            "dm_plex_metric_h_min": Function(P1).assign(1.0e-08),
-            "dm_plex_metric_h_max": Constant(1.0),
-            "dm_plex_metric_a_max": 1.0e05,
-        }
-        metric1.set_parameters(mp1)
-        metric2 = metric1.copy(deepcopy=True)
-        mp2 = metric2.metric_parameters
-        self.assertNotEqual(id(mp1), id(mp2))
-        for key in ("h_min", "h_max", "a_max"):
-            full_key = f"dm_plex_metric_{key}"
-            self.assertNotEqual(id(mp1[full_key]), id(mp2[full_key]))
-
 
 class TestHessianMetric(MetricTestCase):
     """

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -157,13 +157,18 @@ class TestSetParameters(MetricTestCase):
         mesh = uniform_mesh(2)
         metric1 = RiemannianMetric(TensorFunctionSpace(mesh, "CG", 1))
         P1 = FunctionSpace(mesh, "CG", 1)
-        mp1 = {"h_min": Function(P1).assign(1.0), "h_max": 1.0}
+        mp1 = {
+            "dm_plex_metric_h_min": Function(P1).assign(1.0e-08),
+            "dm_plex_metric_h_max": Constant(1.0),
+            "dm_plex_metric_a_max": 1.0e05,
+        }
         metric1.set_parameters(mp1)
         metric2 = metric1.copy(deepcopy=True)
         mp2 = metric2.metric_parameters
         self.assertNotEqual(id(mp1), id(mp2))
-        self.assertNotEqual(id(mp1["h_min"]), id(mp2["h_min"]))
-        self.assertNotEqual(id(mp1["h_max"]), id(mp2["h_max"]))
+        for key in ("h_min", "h_max", "a_max"):
+            full_key = f"dm_plex_metric_{key}"
+            self.assertNotEqual(id(mp1[full_key]), id(mp2[full_key]))
 
 
 class TestHessianMetric(MetricTestCase):

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -153,6 +153,18 @@ class TestSetParameters(MetricTestCase):
         msg = "Normalization order must be in [1, inf)"
         self.assertTrue(str(cm.exception).endswith(msg))
 
+    def test_deepcopy(self):
+        mesh = uniform_mesh(2)
+        metric1 = RiemannianMetric(TensorFunctionSpace(mesh, "CG", 1))
+        P1 = FunctionSpace(mesh, "CG", 1)
+        mp1 = {"h_min": Function(P1).assign(1.0), "h_max": 1.0}
+        metric1.set_parameters(mp1)
+        metric2 = metric1.copy(deepcopy=True)
+        mp2 = metric2.metric_parameters
+        self.assertNotEqual(id(mp1), id(mp2))
+        self.assertNotEqual(id(mp1["h_min"]), id(mp2["h_min"]))
+        self.assertNotEqual(id(mp1["h_max"]), id(mp2["h_max"]))
+
 
 class TestHessianMetric(MetricTestCase):
     """

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -94,13 +94,14 @@ class TestSetParameters(MetricTestCase):
 
     @parameterized.expand([["h_min"], ["h_max"], ["a_max"]])
     def test_set_variable(self, key):
-        value = Constant(1.0)
+        value = 1.0
         metric = uniform_metric(uniform_mesh(2))
-        metric.set_parameters({f"dm_plex_metric_{key}": value})
+        metric.set_parameters({f"dm_plex_metric_{key}": Constant(value)})
         self.assertTrue(f"dm_plex_metric_{key}" not in metric._metric_parameters)
         self.assertTrue(f"dm_plex_metric_{key}" in metric._variable_parameters)
         self.assertTrue(f"dm_plex_metric_{key}" in metric.metric_parameters)
-        self.assertEqual(metric._variable_parameters[f"dm_plex_metric_{key}"], value)
+        param = metric._variable_parameters[f"dm_plex_metric_{key}"]
+        self.assertEqual(float(param), value)
 
     def test_set_boundary_tag(self):
         value = "on_boundary"

--- a/test/test_metric.py
+++ b/test/test_metric.py
@@ -97,20 +97,23 @@ class TestSetParameters(MetricTestCase):
         value = Constant(1.0)
         metric = uniform_metric(uniform_mesh(2))
         metric.set_parameters({f"dm_plex_metric_{key}": value})
-        self.assertTrue(f"dm_plex_metric_{key}" not in metric.metric_parameters)
+        self.assertTrue(f"dm_plex_metric_{key}" not in metric._metric_parameters)
         self.assertTrue(f"dm_plex_metric_{key}" in metric._variable_parameters)
+        self.assertTrue(f"dm_plex_metric_{key}" in metric.metric_parameters)
         self.assertEqual(metric._variable_parameters[f"dm_plex_metric_{key}"], value)
 
     def test_set_boundary_tag(self):
         value = "on_boundary"
         metric = uniform_metric(uniform_mesh(2))
         metric.set_parameters()
-        self.assertTrue("dm_plex_metric_boundary_tag" not in metric.metric_parameters)
+        self.assertTrue("dm_plex_metric_boundary_tag" not in metric._metric_parameters)
         self.assertTrue("dm_plex_metric_boundary_tag" in metric._variable_parameters)
+        self.assertTrue("dm_plex_metric_boundary_tag" not in metric.metric_parameters)
         self.assertIsNone(metric._variable_parameters["dm_plex_metric_boundary_tag"])
         metric.set_parameters({"dm_plex_metric_boundary_tag": value})
-        self.assertTrue("dm_plex_metric_boundary_tag" not in metric.metric_parameters)
+        self.assertTrue("dm_plex_metric_boundary_tag" not in metric._metric_parameters)
         self.assertTrue("dm_plex_metric_boundary_tag" in metric._variable_parameters)
+        self.assertTrue("dm_plex_metric_boundary_tag" in metric.metric_parameters)
         self.assertEqual(
             metric._variable_parameters["dm_plex_metric_boundary_tag"], value
         )


### PR DESCRIPTION
~~Closes #98.~~

~~Fixes the issue with deep-copying metric parameters by **always** deep-copying these parameters upon setting them. (I can't think of a reason why you wouldn't want this.) Also moves some mechanics behind the scenes and provides a public interface to `metric_parameters`.~~

Edit: See discussion in the original issue.

Closes #31.

At long last!